### PR TITLE
Altera pasta dos arquivos convertidos e imagens a serem copiadas

### DIFF
--- a/lib/hugo_to_eex_converter.ex
+++ b/lib/hugo_to_eex_converter.ex
@@ -38,7 +38,7 @@ defmodule HugoToEExConverter do
 
   defp set_new_file_path(file_path) do
     file_path
-    |> String.replace("/convert/", "/converted/")
+    |> String.replace("/convert/", "/converted/priv/markdown_templates/")
     |> String.split(~r/.md$/)
     |> List.first()
   end

--- a/lib/images.ex
+++ b/lib/images.ex
@@ -2,7 +2,7 @@ defmodule HugoToEExConverter.Images do
   @source System.get_env("INPUT_STORAGEPATH")
 
   def copy(source \\ @source) do
-    "#{source}/content/**/*.{png,jpeg,jpg,gif,svg}"
+    "#{source}/**/*.{png,jpeg,jpg,gif,svg}"
     |> Path.wildcard()
     |> Stream.map(&set_new_img_path/1)
     |> Enum.each(&do_copy/1)
@@ -22,6 +22,11 @@ defmodule HugoToEExConverter.Images do
   end
 
   defp set_new_img_path(img_path) do
-    [img_path, String.replace(img_path, "/convert/", "/converted/")]
+    new_img_path =
+      img_path
+      |> String.replace("/convert/content/", "/converted/assets/static/")
+      |> String.replace("/convert/static/", "/converted/assets/static/")
+
+    [img_path, new_img_path]
   end
 end

--- a/test/hugo_to_eex_converter_test.exs
+++ b/test/hugo_to_eex_converter_test.exs
@@ -2,8 +2,8 @@ defmodule HugoToEExConverterTest do
   use ExUnit.Case, async: true
 
   @converted_dir "test/support/converted"
-  @eex_markdown_file_path "test/support/converted/content/module/subject/content.html.md"
-  @frontmatter_file_path "test/support/converted/content/module/subject/content.yaml"
+  @eex_markdown_file_path "test/support/converted/priv/markdown_templates/content/module/subject/content.html.md"
+  @frontmatter_file_path "test/support/converted/priv/markdown_templates/content/module/subject/content.yaml"
 
   setup do
     on_exit(fn -> File.rm_rf(@converted_dir) end)

--- a/test/images_test.exs
+++ b/test/images_test.exs
@@ -3,7 +3,7 @@ defmodule HugoToEExConverter.ImagesTest do
 
   alias HugoToEExConverter.Images
 
-  @img_path "test/support/converted/content/module/subject/trybe.svg"
+  @img_path "test/support/converted/assets/static/module/subject/trybe.svg"
 
   setup do
     on_exit(fn -> File.rm!(@img_path) end)


### PR DESCRIPTION
Foi alterado a estrutura de pastas dos arquivos convertidos e imagens copiadas, para refletir a estrutura no FreeCourse (trybe repo) e a action de abrir o PR não precisar tratar a inserção dos arquivos nos locais corretos.

Exemplo de como fica a estrutura

<img width="301" alt="Screen Shot 2020-06-08 at 16 01 49" src="https://user-images.githubusercontent.com/218034/84069816-8423f800-a9a1-11ea-8ee0-be014e107306.png">

closes #4 